### PR TITLE
Misc Fixes

### DIFF
--- a/Defs/Things/ThingDefs_Resources.xml
+++ b/Defs/Things/ThingDefs_Resources.xml
@@ -292,6 +292,7 @@
     <building>
       <isNaturalRock>false</isNaturalRock>
       <canBuildNonEdificesUnder>true</canBuildNonEdificesUnder>
+	  <smoothedThing/>
     </building>
     <saveCompressible>false</saveCompressible>
     <repairEffect>Repair</repairEffect>

--- a/Languages/English/Keyed/NPS_Keys.xml
+++ b/Languages/English/Keyed/NPS_Keys.xml
@@ -60,7 +60,11 @@
   <TKKN_doWeather_text>If unchecked, none of the below will happen. If checked, only the ones checked below will happen.</TKKN_doWeather_text>
   <TKKN_doTides_title>Do Tides</TKKN_doTides_title>
   <TKKN_doTides_text>Oceans will rise and fall</TKKN_doTides_text>
+  
+  <TKKN_doDirtPath_title>Make dirt paths</TKKN_doDirtPath_title>
+  <TKKN_doDirtPath_text>Pawns pack dirt and sand, and smooth rock floors, as they walk</TKKN_doDirtPath_text>
 
+  
   <TKKN_showTempReadout_title>Show temperature readout</TKKN_showTempReadout_title>
   <TKKN_showTempReadout_text>Show temperature readout in the bottom left</TKKN_showTempReadout_text>
   

--- a/Source/NPS/NPS/HarmonyPatches/Plant.cs
+++ b/Source/NPS/NPS/HarmonyPatches/Plant.cs
@@ -110,6 +110,10 @@ namespace TKKN_NPS
 				}
 			}
 
+            if (String.IsNullOrEmpty(path)) //Need to check if the path is null/empty in case showCold is false and temp is below flower/drought temp
+            {
+                return;
+            }
 
 			if (!map.GetComponent<Watcher>().graphicHolder.ContainsKey(id))
 			{

--- a/Source/NPS/NPS/Save Classes/cellData.cs
+++ b/Source/NPS/NPS/Save Classes/cellData.cs
@@ -54,17 +54,34 @@ namespace TKKN_NPS
 		}
 
 		public void setTerrain(string type) {
-			//Make sure it hasn't been made a floor or a floor hasn't been removed.
-			if (!currentTerrain.HasModExtension<TerrainWeatherReactions>())
-			{
-				this.baseTerrain = currentTerrain;
-			}
-			else if (!baseTerrain.HasModExtension<TerrainWeatherReactions>() && this.baseTerrain != currentTerrain)
-			{
-				this.baseTerrain = currentTerrain;
-			}
-
-			if (weather == null)
+            if (this.map == null) return;
+            //Make sure it hasn't been made a floor or a floor hasn't been removed.
+            if (!currentTerrain.HasModExtension<TerrainWeatherReactions>())
+            {
+                this.baseTerrain = currentTerrain;
+            }
+            else if (!baseTerrain.HasModExtension<TerrainWeatherReactions>() && this.baseTerrain != currentTerrain)
+            {
+                this.baseTerrain = currentTerrain;
+            }
+            else //If the terrain has extentions, make sure the current terrain is one of the possible extentions of the base terrain.  
+				 //If the current terrain isn't an extention of the base, the terrain has been modified (ie Moisture Pump) or terraformed, and the current terrain should replace the base terrain.
+            {
+                var terrainReactions = baseTerrain.GetModExtension<TerrainWeatherReactions>();
+                if (terrainReactions != null)
+                {
+                    if (terrainReactions.tideTerrain != currentTerrain &&
+                        terrainReactions.floodTerrain != currentTerrain &&
+                        terrainReactions.wetTerrain != currentTerrain &&
+                        terrainReactions.freezeTerrain != currentTerrain &&
+                        terrainReactions.dryTerrain != currentTerrain &&
+                        terrainReactions.baseOverride != currentTerrain)
+                    {
+                        this.baseTerrain = currentTerrain;
+                    }
+                }
+            }
+            if (weather == null)
 			{
 				return;
 			}


### PR DESCRIPTION
NPS_Keys XML - Two of the tags had different open and closing tag names, causing the XML to fail to load (I got this XML from the Steam version, the repo doesn't have the tags for dirt paths)

ThingDefs_Resources XML - Re-adding the empty SmoothedThing tag to TKKN_SmoothedLavaRock.  This is required to overwrite the SmoothedThing tag inherited from TKKN_LavaRockBase, otherwise smoothed basalt can be smoothed into smoothed basalt.  (This is the cause of the loading error "TKKN_SmoothedLavaRock and TKKN_LavaRock both smooth to TKKN_SmoothedLavaRock")

Plant.cs - Adding another case to exit the method if the path is still null.  This is required because if weather/cold effects are disabled, and the temp is below 70F/21C, the final attempt to load the image fails due to null path, and all plant images disappear in game).

CellData.cs - Add checking to see if the current terrain is one of the weather transformations of the base terrain.  If it's not, this indicates that the terrain has been terraformed or moisture pumped, and the base needs to be reset to the current.  Without this step, the weather effects will revert the terrain change since both the original and new terrains have terrain extensions (bypassing the existing swap logic), but the new terrain ends up having transformations applied based on the original terrain.